### PR TITLE
Incremental index updates + fix metadata.uploaded

### DIFF
--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -1,4 +1,4 @@
-import { updateIndex } from "./indices";
+import { appendToIndex } from "./indices";
 import { LIMIT_EXCEEDED_MESSAGE, RateLimitedOpenAI } from "./openai";
 import { marked } from "marked";
 
@@ -144,8 +144,10 @@ export async function getArticle(
       );
     }
 
-    await articles.put(urlPath || "404", guideEntry);
-    await updateIndex(articles, "articles", indices);
+    const key = urlPath || "404";
+    const uploaded = Date.now();
+    await articles.put(key, guideEntry, { metadata: { uploaded } });
+    await appendToIndex(indices, "articles", { name: key, metadata: { uploaded } });
 
     return marked(guideEntry);
   } catch (error) {

--- a/src/lib/indices.ts
+++ b/src/lib/indices.ts
@@ -1,4 +1,6 @@
-const EXPIRATION_TTL = 86400; /**
+const EXPIRATION_TTL = 86400;
+
+/**
  * Retrieve a cached list of KV keys for the given index, using the `indices` namespace when available.
  *
  * If a cached entry exists in `indices` for `indexKey`, that list is returned. If no cache entry
@@ -48,4 +50,35 @@ export async function updateIndex<T>(
   });
 
   return keys;
+}
+
+/**
+ * Append a single entry to a cached index without re-listing the entire KV namespace.
+ *
+ * Reads the current index from `indices`, dedupes by `name` (replacing any existing entry
+ * with the same name), appends the new entry, and writes the updated list back with the
+ * standard 24-hour TTL. If the index has not been cached yet (null/missing), this is a
+ * no-op — the next consumer will rebuild it via `getIndex` → `updateIndex`. If `indices`
+ * is missing entirely, returns early.
+ *
+ * @param indexKey - Which index to append to ("articles" or "searches").
+ * @param entry - The KV key entry to append (must include `name` and optional `metadata`).
+ */
+export async function appendToIndex<T>(
+  indices: KVNamespace | undefined,
+  indexKey: "articles" | "searches",
+  entry: KVNamespaceListKey<T>
+): Promise<void> {
+  if (!indices) return;
+
+  const index = await indices.get<KVNamespaceListKey<T>[]>(indexKey, "json");
+
+  if (!index) return;
+
+  const filtered = index.filter((existing) => existing.name !== entry.name);
+  filtered.push(entry);
+
+  await indices.put(indexKey, JSON.stringify(filtered), {
+    expirationTtl: EXPIRATION_TTL,
+  });
 }


### PR DESCRIPTION
## Summary

Closes #9. Refs #12.

Two related fixes to the article indices implementation:

- **Fix `metadata.uploaded`**: `articles.put()` in `src/lib/getArticle.ts` previously stored entries without metadata, leaving `metadata.uploaded` undefined and breaking `getLatestArticle`'s sort. The put now writes `{ metadata: { uploaded: Date.now() } }`.
- **Incremental index updates**: `updateIndex` in `src/lib/indices.ts` re-listed every key via `kv.list()` on each article creation. Added a new `appendToIndex` helper that reads the cached index from `INDICES`, dedupes by `name`, appends the new entry, and writes back with the existing 24h TTL. `appendToIndex` is a no-op when the index hasn't been cached yet — the next consumer rebuilds via `getIndex` → `updateIndex`. The cold-start `updateIndex` / `getIndex` path is untouched.

## Test plan

- [x] `pnpm install`
- [x] `pnpm build`
- [x] `pnpm check`
- [ ] Manual smoke: generate a new article in dev, confirm the cached `articles` index in `INDICES` gains the new entry with an `uploaded` timestamp without a fresh `kv.list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)