### PR TITLE
fix(deploy): use wrangler deploy for Workers, not Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy to Cloudflare Workers
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     concurrency:
-      group: cloudflare-pages-${{ github.ref }}
+      group: cloudflare-workers-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
@@ -35,7 +35,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy
-        run: pnpm exec wrangler pages deploy dist --project-name hitchhikers-ai
+        run: pnpm exec wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

The deploy step added in #29 called `wrangler pages deploy ...`, which failed in Actions with:

> Project not found. The specified project name does not match any of your existing projects. [code: 8000007]

This project is a **Cloudflare Worker with static assets**, not a Pages project. `wrangler.jsonc` has:

- `main: "dist/_worker.js/index.js"` — Worker entry
- `assets: { directory: "dist" }` — Workers Static Assets
- `kv_namespaces: [...]` — KV bindings

…and `astro.config.mjs` uses `@astrojs/cloudflare` with `output: 'server'`, which produces a Worker bundle.

This PR swaps the deploy command to `wrangler deploy`, which picks up the project name, entry, assets, and KV bindings from `wrangler.jsonc` automatically — no `--project-name` flag needed.

## Test plan

- [ ] Merge → workflow runs on push to `main`
- [ ] `Deploy` step succeeds and the Worker (with new build) is live at the existing `*.workers.dev` URL / custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure and automated workflow configuration to optimize the deployment pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/hitchhikers-ai/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->