### PR TITLE
fix: keep the Guide up when OpenAI is unavailable

### DIFF
--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -93,10 +93,11 @@ async function getArticleImage(
  * Retrieve (from cache) or generate a Hitchhiker's Guide–style article for a given URL path, cache it, update the indices, and return the article rendered as HTML.
  *
  * This function:
- * - Validates the topic is safe for work and throws Error("This topic is not safe for work.") if not.
  * - Normalizes `urlPath` into a human-friendly `formattedPath`.
- * - Returns a cached HTML article if present.
+ * - Returns a cached HTML article if present, without contacting OpenAI.
  * - If not cached, enforces usage limits and returns a limit message when exceeded.
+ * - Validates the topic is safe for work and throws Error("This topic is not safe for work.") if not.
+ *   If the moderation check itself fails, returns the limit message rather than generating.
  * - Generates article text and an optional image, prefixes the image to the article when produced, stores the result in `articles`, updates the index via `indices`, and returns the article HTML.
  *
  * @param urlPath - The requested path (e.g., "/some-topic"); used to look up and name the article. An empty or missing `urlPath` is treated as "404".
@@ -110,22 +111,35 @@ export async function getArticle(
   urlPath: string,
   indices: KVNamespace
 ) {
-  const openai = new RateLimitedOpenAI(apiKey, tokenUsage);
-  const isSafe = await openai.isSafe(urlPath);
-
-  if (!isSafe) {
-    throw new Error("This topic is not safe for work.");
-  }
-
   const formattedPath = urlPath?.replace(/[/-]/g, " ").trim() || "404";
+
+  // Serve from KV before touching OpenAI at all. Moderating a path we already
+  // have an article for is wasted spend, and — more importantly — an OpenAI
+  // outage or rate limit used to take down every already-generated article.
   const cachedEntry = await articles.get(urlPath || "404", "text");
 
   if (cachedEntry) {
     return marked(cachedEntry);
   }
 
+  const openai = new RateLimitedOpenAI(apiKey, tokenUsage);
+
   if (await openai.didExceedLimit()) {
     return LIMIT_EXCEEDED_MESSAGE;
+  }
+
+  // Fail closed: if moderation is unavailable we don't generate, but we say so
+  // in the Guide's voice rather than throwing a 500 at the reader.
+  let isSafe: boolean;
+  try {
+    isSafe = await openai.isSafe(urlPath);
+  } catch (error) {
+    console.error("Moderation check failed:", error);
+    return LIMIT_EXCEEDED_MESSAGE;
+  }
+
+  if (!isSafe) {
+    throw new Error("This topic is not safe for work.");
   }
 
   try {

--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -90,6 +90,22 @@ async function getArticleImage(
 }
 
 /**
+ * Whether a stored ARTICLES value is really an outage notice rather than an article.
+ *
+ * Before the guard in `getArticle` existed, a rate-limited generation could be written to
+ * KV in either of two shapes: the notice alone, or — when the image call happened to
+ * succeed while the text call was rate-limited — an `<img>` tag prepended to it as
+ * `${image}\n\n${text}`. Both must be recognised, or a poisoned slug gets rendered as a
+ * real article and edge-cached for a day.
+ */
+function isOutageNotice(stored: string): boolean {
+  return (
+    stored === LIMIT_EXCEEDED_MESSAGE ||
+    stored.endsWith(`\n\n${LIMIT_EXCEEDED_MESSAGE}`)
+  );
+}
+
+/**
  * Retrieve (from cache) or generate a Hitchhiker's Guide–style article for a given URL path, cache it, update the indices, and return the article rendered as HTML.
  *
  * This function:
@@ -121,7 +137,11 @@ export async function getArticle(
   // outage or rate limit used to take down every already-generated article.
   const cachedEntry = await articles.get(urlPath || "404", "text");
 
-  if (cachedEntry) {
+  // A slug poisoned by an earlier outage — the notice stored as its article, before
+  // the guard further down existed — is treated as a miss rather than rendered. That
+  // way it regenerates once the provider recovers instead of serving the notice
+  // forever, and marked() can't disguise it from the caller's identity check.
+  if (cachedEntry && !isOutageNotice(cachedEntry)) {
     return marked(cachedEntry);
   }
 

--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -101,7 +101,8 @@ async function getArticleImage(
  * - Generates article text and an optional image, prefixes the image to the article when produced, stores the result in `articles`, updates the index via `indices`, and returns the article HTML.
  *
  * @param urlPath - The requested path (e.g., "/some-topic"); used to look up and name the article. An empty or missing `urlPath` is treated as "404".
- * @returns The article as HTML (marked output).
+ * @returns The article as HTML (marked output) when served from cache or freshly generated; otherwise the
+ * plain-text `LIMIT_EXCEEDED_MESSAGE` when the daily usage limit is spent or the moderation check itself fails.
  * @throws Error when the topic is deemed unsafe for work. Other errors encountered during generation are propagated to the caller.
  */
 export async function getArticle(
@@ -144,6 +145,16 @@ export async function getArticle(
 
   try {
     const text = await getArticleText(openai, formattedPath);
+
+    // createChatCompletion swallows a 429 and hands back the limit notice in a
+    // normal completion shape, so `text` can be the notice rather than an article.
+    // Storing it would poison the slug permanently — ARTICLES entries carry no TTL
+    // — and appendToIndex would then surface it in the random recommendations.
+    // getSearchResults guards its own KV write the same way.
+    if (text === LIMIT_EXCEEDED_MESSAGE) {
+      return LIMIT_EXCEEDED_MESSAGE;
+    }
+
     let guideEntry = text;
 
     try {

--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -102,7 +102,9 @@ async function getArticleImage(
  *
  * @param urlPath - The requested path (e.g., "/some-topic"); used to look up and name the article. An empty or missing `urlPath` is treated as "404".
  * @returns The article as HTML (marked output) when served from cache or freshly generated; otherwise the
- * plain-text `LIMIT_EXCEEDED_MESSAGE` when the daily usage limit is spent or the moderation check itself fails.
+ * plain-text `LIMIT_EXCEEDED_MESSAGE` when the daily usage limit is spent, the moderation check itself
+ * fails, or generation is rate-limited upstream. Callers rely on that sentinel being returned by
+ * identity to detect a transient failure, so it is deliberately not passed through `marked()`.
  * @throws Error when the topic is deemed unsafe for work. Other errors encountered during generation are propagated to the caller.
  */
 export async function getArticle(

--- a/src/lib/getSearchResults.ts
+++ b/src/lib/getSearchResults.ts
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import { RateLimitedOpenAI } from "./openai";
+import { LIMIT_EXCEEDED_MESSAGE, RateLimitedOpenAI } from "./openai";
 
 export async function getSearchResults(
   query: string,
@@ -18,7 +18,16 @@ export async function getSearchResults(
     return marked(cachedResults);
   }
 
-  const isSafe = await openai.isSafe(query);
+  // Fail closed: if moderation is unavailable we don't generate, but we say so in
+  // the Guide's voice rather than throwing a 500 at the reader. An unguarded call
+  // here is what took the article path down during an OpenAI outage.
+  let isSafe: boolean;
+  try {
+    isSafe = await openai.isSafe(query);
+  } catch (error) {
+    console.error("Moderation check failed:", error);
+    return LIMIT_EXCEEDED_MESSAGE;
+  }
 
   if (!isSafe) {
     return "This topic is not safe for work.";
@@ -43,7 +52,7 @@ export async function getSearchResults(
   const content = completion.choices[0].message.content || "";
 
   // Only cache if it's not a limit exceeded response
-  if (!content.includes("currently overloaded with requests")) {
+  if (content !== LIMIT_EXCEEDED_MESSAGE) {
     await searches.put(query, content);
   }
 

--- a/src/lib/getSearchResults.ts
+++ b/src/lib/getSearchResults.ts
@@ -51,10 +51,14 @@ export async function getSearchResults(
 
   const content = completion.choices[0].message.content || "";
 
-  // Only cache if it's not a limit exceeded response
-  if (content !== LIMIT_EXCEEDED_MESSAGE) {
-    await searches.put(query, content);
+  // createChatCompletion returns the notice in a normal completion shape when it
+  // swallows a 429, so bail before storing it — and return it raw, matching the
+  // moderation-failure path above rather than rendering the same string two ways.
+  if (content === LIMIT_EXCEEDED_MESSAGE) {
+    return LIMIT_EXCEEDED_MESSAGE;
   }
+
+  await searches.put(query, content);
 
   return marked(content);
 }

--- a/src/pages/api/article/[...path].ts
+++ b/src/pages/api/article/[...path].ts
@@ -1,4 +1,5 @@
 import { getArticle } from "../../../lib/getArticle";
+import { LIMIT_EXCEEDED_MESSAGE } from "../../../lib/openai";
 import type { APIContext } from "astro";
 
 export const prerender = false;
@@ -48,7 +49,9 @@ export function isValidArticlePath(path: string): boolean {
  * message and a user-facing `content` notice.
  *
  * Successful (200) responses are cached at the Cloudflare edge using the Workers Cache API
- * keyed on the request URL, so repeat views skip the ARTICLES KV read entirely.
+ * keyed on the request URL, so repeat views skip the ARTICLES KV read entirely. Rate-limit and
+ * outage notices are returned as 200s but sent `no-store` and never cached, so a transient
+ * failure can't outlive the condition that produced it (see #25: failures aren't cached).
  *
  * @param params.path - Route path captured by Astro; may be a string or string[] (arrays are joined with `/`)
  * @returns A Response with a JSON body. Success: status 200 and `{ content }`. Failure: status 500 and `{ error, content }`.
@@ -123,15 +126,22 @@ export async function GET({ params, locals, request }: APIContext) {
       throw new Error("No content generated");
     }
 
+    // A limit/outage notice is a temporary condition, not an article. Caching it
+    // would outlive the condition that produced it — a moments-long OpenAI blip
+    // would be served from the edge for a full day. Keep #25's rule intact:
+    // failures aren't cached, whichever side of the 200/500 line they land on.
+    const isNotice = content === LIMIT_EXCEEDED_MESSAGE;
+
     const response = new Response(JSON.stringify({ content }), {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control":
-          "public, s-maxage=86400, stale-while-revalidate=86400",
+        "Cache-Control": isNotice
+          ? "no-store"
+          : "public, s-maxage=86400, stale-while-revalidate=86400",
       },
     });
 
-    if (cache) {
+    if (cache && !isNotice) {
       await cache.put(cacheKey, response.clone());
     }
 


### PR DESCRIPTION
Every article on guide.nathanarthur.com is currently returning `IMPROBABILITY_OVERFLOW` — including entries generated months ago. So is search.

```
$ curl https://guide.nathanarthur.com/api/article/babel-fish
{"error":"429 Too Many Requests","content":"...technical difficulties..."}

$ curl "https://guide.nathanarthur.com/api/search?q=towel"
{"error":"429 Too Many Requests","content":"...technical difficulties..."}
```

## Root cause

OpenAI is returning 429 on every call for this account (a separate, upstream problem — see *Still to do*). But the reason a provider outage takes down *cached* content is ours:

`getArticle()` called `openai.isSafe()` — the moderations endpoint — **before** reading ARTICLES KV. It was the only OpenAI call in that path without error handling; `createChatCompletion` already catches 429s and returns `LIMIT_EXCEEDED_MESSAGE`. So one unguarded call turned an upstream hiccup into a total outage, including for content that needed zero OpenAI to serve. `getSearchResults()` already had the right ordering — the article path was the outlier.

## Changes

**1. Serve from KV before touching OpenAI** (`getArticle.ts`). The read path no longer instantiates the client, checks the budget, or moderates. A cached article is now completely independent of provider health.

**2. Fail closed, politely, on a moderation error.** A failed `isSafe()` returns `LIMIT_EXCEEDED_MESSAGE` instead of throwing — no generation happens, but the reader gets the Guide's voice rather than a 500.

**3. Never persist or cache a transient failure as content.** Fixing (1) and (2) surfaced four places where an outage notice was treated as though it were an article:

- The API handler edge-cached `LIMIT_EXCEEDED_MESSAGE` as a 200 with `s-maxage=86400`, so a seconds-long blip would be served from the edge for a day. This was a **regression introduced by (2)** — previously it threw, and 500s are never cached. It also contradicted the rule stated in #25 ("Error (500) responses are not cached"). Now sent `no-store` and skipped.
- `getArticle` wrote the notice to ARTICLES KV whenever `createChatCompletion` swallowed a 429. KV entries carry no TTL, so a slug requested during an outage would serve the notice **permanently**, and `appendToIndex` would surface it in the random recommendations.
- Slugs *already* poisoned that way were passed through `marked()` on the read path, which disguised them from the handler's identity check — so they were served as real articles and publicly edge-cached. Now treated as a cache miss, so they regenerate once the provider recovers and existing damage self-heals. Both stored shapes are matched: the notice alone, and an `<img>` prepended to it (the pre-fix code built `${image}\n\n${text}` without checking whether `text` was the notice).
- `getSearchResults` still had the unguarded `isSafe()` call — the same shape that took the article path down, and why `/api/search` is 500ing right now. Same fail-closed handling applied.

## Verification

Run locally against `wrangler dev` with an invalid API key, which makes every OpenAI call throw — the same code path as the production 429. Articles pre-seeded into local KV.

| Case | Before (= prod today) | After |
|---|---|---|
| Cached article | 500 `IMPROBABILITY_OVERFLOW` | 200, article HTML, `s-maxage=86400` |
| Uncached article | 500 `IMPROBABILITY_OVERFLOW` | 200, in-voice notice, `no-store` |
| Search | 500 `IMPROBABILITY_OVERFLOW` | 200, in-voice notice |
| Poisoned entry (`<notice>`) | rendered as an article, cached 24h | 200, `no-store`, regenerates on recovery |
| Poisoned entry (`<img …>\n\n<notice>`) | rendered as an article, cached 24h | 200, `no-store`, regenerates on recovery |
| ARTICLES KV after the above | — | unchanged; no notice written |

`astro check`: 0 errors, 0 warnings.

**No automated tests.** The repo has no test suite or test tooling, so the above is manual verification. Standing up a runner plus KV/OpenAI mocks is a larger call than this fix and is left to the owner.

## Still to do (not in this PR)

**The 429 itself.** Nothing here fixes it — a bare `429 Too Many Requests` across all endpoints, moderations included, points at exhausted credits or a project rate limit of zero. Needs checking at platform.openai.com. Until then new articles won't generate; they'll say so politely, and will generate normally once the account is healthy.

The review also surfaced pre-existing issues left out of scope deliberately, each worth its own issue:

- The generated article body and image prompt are never moderated — only the URL slug is.
- The frontend assigns unsanitized `marked()` output via `innerHTML`, a stored-XSS path.
- `isSafe()` receives the raw kebab-case slug while generation is prompted with the de-kebab'd text, so moderation sees different input than the model.
- Concurrent first requests for the same new slug each generate independently, duplicating spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC6UUjCk6wM8B5np7vp7h