### PR TITLE
fix: stop llama-4 emitting dead links and a duplicate heading

### DIFF
--- a/src/lib/getArticle.ts
+++ b/src/lib/getArticle.ts
@@ -21,6 +21,11 @@ async function getArticleText(ai: RateLimitedAI, formattedPath: string) {
          Write [A Good Towel](/towel) instead
       10. At most one link per sentence. Prose first, links second — an entry that is
           mostly links reads as a directory, not a Guide entry
+      11. A URL is ONE path segment: a single leading slash and no others. /babel-fish is
+          valid. /definitions/sanity and /galactic-directory/therapies are NOT — the Guide
+          has no sections, and such links lead nowhere
+      12. Do NOT open with a heading or the entry's title. The Guide renders the title
+          itself; start directly with the first sentence of prose
       
       Example of CORRECT linking (Use this style):
       "The [Babel Fish](/babel-fish) is a remarkable creature studied at the [Galactic Institute of Xenobiology](/galactic-institute-of-xenobiology). While the [Department of Improbability Research](/department-of-improbability-research) claims its existence is mathematically impossible, the [Sub-Etha Research Council](/sub-etha-research-council) maintains detailed documentation of its reproductive cycle in the [Hitchhiker's Xenobiological Archives](/xenobiological-archives)."
@@ -32,7 +37,7 @@ async function getArticleText(ai: RateLimitedAI, formattedPath: string) {
     },
     {
       role: "user",
-      content: `Write a Hitchhiker's Guide to the Galaxy style entry about "${formattedPath}". Make it humorous and slightly absurd, as if it's an entry in the actual Guide. Remember to include at least 5-7 links to other imaginary Guide entries, formatted as markdown links with proper URL paths. Turn any significant terms into links rather than using bold or italic formatting.`,
+      content: `Write a Hitchhiker's Guide to the Galaxy style entry about "${formattedPath}". Make it humorous and slightly absurd, as if it's an entry in the actual Guide. Include 5-8 links to other imaginary Guide entries, each a single-segment kebab-case path like /babel-fish. Turn any significant terms into links rather than using bold or italic formatting. Start with prose, not a heading.`,
     },
   ]);
 }


### PR DESCRIPTION
Two regressions visible in the first real production entry generated after #32, neither present with gpt-3.5-turbo.

## Dead links

`llama-4-scout` invents directory-style paths. From the live `/sanity-company` entry:

```
/definitions/sanity
/biographies/zorvath
/galactic-directory/mental-health-services
/galactic-directory/unconventional-therapies
```

`isValidArticlePath` allows no slashes past the first (`/^[a-z0-9]+(-[a-z0-9]+){0,9}$/`), so all four 404. **4 of 18 links dead — 22%.** gpt-3.5-turbo kept to single segments, so this is new.

## Duplicate heading

The model opens with its own `<h1>` repeating the entry title, which `[...path].astro` already renders as `<h1 class="article-title">`. Two `<h1>`s per page.

## Fix

Two prompt rules: a URL is one path segment; start with prose, not a heading.

## Verified against the real model

| Topic | links | dead | headings | nested |
|---|---|---|---|---|
| sanity company | 28 | 0 | 0 | 0 |
| quantum teapot | 12 | 0 | 0 | 0 |
| bureau of lost socks | 16 | 0 | 0 | 0 |
| improbable tea | 14 | 0 | 0 | 0 |

Link count still varies more than the prompt asks (12–28 vs 5–8), but every link is now well-formed and resolvable.

## Note

Entries generated between #32 deploying and this landing have the dead links baked into KV. `/sanity-company` is one — I generated it while testing. Deleting those keys makes them regenerate cleanly; happy to do it on request, but it's production data so I haven't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC6UUjCk6wM8B5np7vp7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Generation**
  * Improved generated articles by requiring 5–8 concise, single-segment links.
  * Standardized link formatting with a single leading slash and kebab-case paths.
  * Prevented generated articles from starting with a heading or title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->